### PR TITLE
output sql_comment when specify

### DIFF
--- a/lib/Dongry/Database.pm
+++ b/lib/Dongry/Database.pm
@@ -450,6 +450,11 @@ sub execute ($$;$%) {
     ($sql, $values) = _where [$sql, %$values];
   }
   
+  if ($self->{sources}->{$name}->{sql_comment}) {
+    my $comment = $self->{sources}->{$name}->{sql_comment};
+    $comment =~ s{\*/}{\* /}g;
+    $sql .= ' /* ' . $comment . ' */';
+  }
   if ($EmbedCallerInSQL) {
     my $caller = _get_caller;
     my $text = $name . ' at ' . $caller->{file} . ' line ' . $caller->{line};

--- a/lib/Dongry/Database.pod
+++ b/lib/Dongry/Database.pod
@@ -236,6 +236,11 @@ Informative name of the data source.  It is not used to connect to the
 data source.  This value might or might not be useful for debugging.
 Default is same as C<dsn>.
 
+=item sql_comment => string
+
+Comment string which embedded in SQL. When this source is used, specified
+string is always embedded in.
+
 =back
 
 Although it is in theory possible to modify the hash reference after

--- a/t/database/sqlcomment.t
+++ b/t/database/sqlcomment.t
@@ -1,0 +1,69 @@
+package test::Dongry::Database::sqlcomment;
+use strict;
+use warnings;
+use Path::Class;
+use lib file (__FILE__)->dir->parent->subdir ('lib')->stringify;
+use Test::Dongry;
+use base qw(Test::Class);
+use Dongry::Database;
+
+sub _execute_plain : Test(1) {
+  my $db = new_db;
+
+  $db->execute ('show tables');
+
+  is $db->{last_sql}, 'show tables';
+} # _execute_plain
+
+sub _execute_commented : Test(1) {
+  reset_db_set;
+  my $dsn = test_dsn 'createtable';
+  my $db = Dongry::Database->new
+      (sources => {default => {dsn => $dsn, sql_comment => '*/ hello-dongry /*'}});
+
+  $db->execute ('show tables');
+
+  is $db->{last_sql},
+      'show tables /* * / hello-dongry /* */';
+} # _execute_commented
+
+sub _select_commented : Test(1) {
+  reset_db_set;
+  my $dsn = test_dsn 'createtable';
+  my $db = Dongry::Database->new
+      (sources => {master  => {dsn => $dsn, writable => 1, sql_comment => '*/ hello-dongry /*'},
+                   default => {dsn => $dsn, sql_comment => '*/ hello-dongry /*'}});
+  $db->execute ('create table foo (id int)');
+
+  $db->select ('foo', {id => 1});
+
+  is $db->{last_sql},
+      'SELECT * FROM `foo` WHERE `id` = ? /* * / hello-dongry /* */';
+} # _select_commented
+
+sub _insert_commented : Test(1) {
+  reset_db_set;
+  my $dsn = test_dsn 'createtable';
+  my $db = Dongry::Database->new
+      (sources => {master  => {dsn => $dsn, writable => 1, sql_comment => '*/ hello-dongry /*'},
+                   default => {dsn => $dsn, sql_comment => '*/ hello-dongry /*'}});
+  $db->execute ('create table foo (id int)');
+
+  $db->insert ('foo', [{id => 1}]);
+
+  is $db->{last_sql},
+      'INSERT INTO `foo` (`id`) VALUES (?) /* * / hello-dongry /* */';
+} # _insert_commented
+
+__PACKAGE__->runtests;
+
+1;
+
+=head1 LICENSE
+
+Copyright 2012 Wakaba <w@suika.fam.cx>.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
support $db->{sources}{source_name}{sql_comment} option.
sql_comment is string, and it output to sql as comment.
